### PR TITLE
Feature/oauth fix

### DIFF
--- a/src/main/java/com/b4f2/pting/domain/Member.java
+++ b/src/main/java/com/b4f2/pting/domain/Member.java
@@ -24,22 +24,22 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    Long id;
+    private Long id;
 
     @NotNull
-    Long oauthId;
+    private Long oauthId;
 
     @NotNull
     @Enumerated(EnumType.STRING)
-    OAuthProvider oauthProvider;
+    private OAuthProvider oauthProvider;
 
-    String name;
+    private String name;
 
-    String imageUrl;
+    private String imageUrl;
 
-    String schoolEmail;
+    private String schoolEmail;
 
-    Boolean isVerified = false;
+    private Boolean isVerified = false;
 
     public enum OAuthProvider {
         KAKAO

--- a/src/main/java/com/b4f2/pting/service/AuthService.java
+++ b/src/main/java/com/b4f2/pting/service/AuthService.java
@@ -21,6 +21,7 @@ import com.b4f2.pting.util.JwtUtil;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuthService {
 
     private final KakaoOAuthProperties kakaoOAuthProperties;
@@ -28,7 +29,6 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final JwtUtil jwtUtil;
 
-    @Transactional(readOnly = true)
     public OAuthUrlResponse getKakaoOAuthUrl() {
         return new OAuthUrlResponse(
             kakaoOAuthProperties.authUri()

--- a/src/test/java/com/b4f2/pting/service/AuthServiceTest.java
+++ b/src/test/java/com/b4f2/pting/service/AuthServiceTest.java
@@ -1,0 +1,41 @@
+package com.b4f2.pting.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.b4f2.pting.domain.properties.KakaoOAuthProperties;
+import com.b4f2.pting.dto.OAuthUrlResponse;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+    @Mock
+    private KakaoOAuthProperties kakaoOAuthProperties;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    void 카카오_OAuth_로그인_URL_조회() {
+        // given
+        given(kakaoOAuthProperties.authUri()).willReturn("kakao_auth_uri");
+        given(kakaoOAuthProperties.clientId()).willReturn("client_id");
+        given(kakaoOAuthProperties.redirectUri()).willReturn("redirect_uri");
+
+        // when
+        OAuthUrlResponse urlResponse = authService.getKakaoOAuthUrl();
+
+        // then
+        assertThat(urlResponse).isEqualTo(
+            new OAuthUrlResponse("kakao_auth_uri?client_id=client_id&redirect_uri=redirect_uri&response_type=code")
+        );
+    }
+
+    // TODO: 로그인 처리 메서드에 대한 테스트코드 작성하기!
+}


### PR DESCRIPTION
- 멤버 엔티티 필드에 `private` 속성을 추가했습니다
- `AuthService`의 트랜잭션 처리 방식을 다른 서비스 클래스들과 통일해줬습니다
  - 클래스에 `@Transactional(readOnly = true)`를 붙임
  - `readOnly`가 아닌 트랜잭션이 필요한 메서드에만 선택적으로 `@Transactional`을 붙임
- `getKakaoOAuthUrl()` 메서드의 테스트코드를 작성했습니다
  - `RestClient`와 `kakaoOAuthLogin()` 메서드의 테스트코드는 조금 더 공부해서 다음주중으로 작성하도록 하겠습니다!