### PR TITLE
Refactor/oauth

### DIFF
--- a/src/main/java/com/b4f2/pting/config/properties/KakaoOAuthProperties.java
+++ b/src/main/java/com/b4f2/pting/config/properties/KakaoOAuthProperties.java
@@ -1,4 +1,4 @@
-package com.b4f2.pting.domain.properties;
+package com.b4f2.pting.config.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/src/main/java/com/b4f2/pting/service/AuthService.java
+++ b/src/main/java/com/b4f2/pting/service/AuthService.java
@@ -9,9 +9,9 @@ import org.springframework.web.client.RestClient;
 
 import lombok.RequiredArgsConstructor;
 
+import com.b4f2.pting.config.properties.KakaoOAuthProperties;
 import com.b4f2.pting.domain.Member;
 import com.b4f2.pting.domain.Member.OAuthProvider;
-import com.b4f2.pting.domain.properties.KakaoOAuthProperties;
 import com.b4f2.pting.dto.AuthResponse;
 import com.b4f2.pting.dto.KakaoOAuthTokenResponse;
 import com.b4f2.pting.dto.KakaoUserInfoResponse;

--- a/src/main/java/com/b4f2/pting/service/AuthService.java
+++ b/src/main/java/com/b4f2/pting/service/AuthService.java
@@ -1,11 +1,7 @@
 package com.b4f2.pting.service;
 
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClient;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +14,7 @@ import com.b4f2.pting.dto.KakaoUserInfoResponse;
 import com.b4f2.pting.dto.OAuthUrlResponse;
 import com.b4f2.pting.repository.MemberRepository;
 import com.b4f2.pting.util.JwtUtil;
+import com.b4f2.pting.util.KakaoOAuthClient;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +22,7 @@ import com.b4f2.pting.util.JwtUtil;
 public class AuthService {
 
     private final KakaoOAuthProperties kakaoOAuthProperties;
-    private final RestClient restClient;
+    private final KakaoOAuthClient kakaoOAuthClient;
     private final MemberRepository memberRepository;
     private final JwtUtil jwtUtil;
 
@@ -42,24 +39,8 @@ public class AuthService {
 
     @Transactional
     public AuthResponse kakaoOAuthLogin(String code) {
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", kakaoOAuthProperties.clientId());
-        params.add("redirect_uri", kakaoOAuthProperties.redirectUri());
-        params.add("code", code);
-
-        KakaoOAuthTokenResponse token = restClient.post()
-            .uri(kakaoOAuthProperties.tokenUri())
-            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-            .body(params)
-            .retrieve()
-            .body(KakaoOAuthTokenResponse.class);
-
-        KakaoUserInfoResponse userInfo = restClient.post()
-            .uri(kakaoOAuthProperties.infoUri())
-            .header("Authorization", "Bearer " + token.accessToken())
-            .retrieve()
-            .body(KakaoUserInfoResponse.class);
+        KakaoOAuthTokenResponse token = kakaoOAuthClient.getKakaoOAuthToken(code);
+        KakaoUserInfoResponse userInfo = kakaoOAuthClient.getKakaoUserInfo(token);
 
         Member member = memberRepository.findByOauthIdAndOauthProvider(userInfo.id(), OAuthProvider.KAKAO)
             .orElseGet(() -> memberRepository.save(new Member(userInfo.id(), OAuthProvider.KAKAO)));

--- a/src/main/java/com/b4f2/pting/util/KakaoOAuthClient.java
+++ b/src/main/java/com/b4f2/pting/util/KakaoOAuthClient.java
@@ -1,0 +1,44 @@
+package com.b4f2.pting.util;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import lombok.RequiredArgsConstructor;
+
+import com.b4f2.pting.config.properties.KakaoOAuthProperties;
+import com.b4f2.pting.dto.KakaoOAuthTokenResponse;
+import com.b4f2.pting.dto.KakaoUserInfoResponse;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthClient {
+
+    private final RestClient restClient;
+    private final KakaoOAuthProperties kakaoOAuthProperties;
+
+    public KakaoOAuthTokenResponse getKakaoOAuthToken(String code) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoOAuthProperties.clientId());
+        params.add("redirect_uri", kakaoOAuthProperties.redirectUri());
+        params.add("code", code);
+
+        return restClient.post()
+            .uri(kakaoOAuthProperties.tokenUri())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(params)
+            .retrieve()
+            .body(KakaoOAuthTokenResponse.class);
+    }
+
+    public KakaoUserInfoResponse getKakaoUserInfo(KakaoOAuthTokenResponse token) {
+        return restClient.post()
+            .uri(kakaoOAuthProperties.infoUri())
+            .header("Authorization", "Bearer " + token.accessToken())
+            .retrieve()
+            .body(KakaoUserInfoResponse.class);
+    }
+}

--- a/src/test/java/com/b4f2/pting/service/AuthServiceTest.java
+++ b/src/test/java/com/b4f2/pting/service/AuthServiceTest.java
@@ -9,7 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.b4f2.pting.domain.properties.KakaoOAuthProperties;
+import com.b4f2.pting.config.properties.KakaoOAuthProperties;
 import com.b4f2.pting.dto.OAuthUrlResponse;
 
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
- `KakaoOAuthProperties` 클래스의 위치를 `domain` 패키지에서 `config` 패키지로 옮겼습니다
- `kakaoOAuthLogin` 로그인 로직 중 외부(카카오) API를 호출하는 부분은 클래스를 나누어 책임을 분리했습니다