### PR TITLE
Feature/alarm trigger

### DIFF
--- a/src/main/java/com/b4f2/pting/repository/GameRepository.java
+++ b/src/main/java/com/b4f2/pting/repository/GameRepository.java
@@ -25,10 +25,11 @@ public interface GameRepository extends JpaRepository<Game, Long> {
     List<Game> findAllByGameStatusAndSportIdAndTimePeriod(Game.GameStatus status, Long sportId, LocalTime startTime, LocalTime endTime);
 
     @Modifying
-    @Query("""
-            update Game g
-            set g.gameStatus = 'END'
-            where g.gameStatus = 'ON_MATCHING' and g.startTime <= :deadline
-        """)
-    int endMatchingGames(@Param("deadline") LocalDateTime deadLine);
+    @Query(value = """
+            update game
+            set game_status = 'END'
+            where game_status = 'ON_MATCHING' and start_time <= :deadline
+            returning *
+        """, nativeQuery = true)
+    List<Game> endMatchingGames(@Param("deadline") LocalDateTime deadLine);
 }

--- a/src/main/java/com/b4f2/pting/scheduler/GameScheduler.java
+++ b/src/main/java/com/b4f2/pting/scheduler/GameScheduler.java
@@ -2,7 +2,9 @@ package com.b4f2.pting.scheduler;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.List;
 
+import com.b4f2.pting.domain.Game;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -21,7 +23,14 @@ public class GameScheduler {
     @Scheduled(cron = "0 */5 * * * *")
     public void endMatchingGamesJob() {
         LocalDateTime deadLine = LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusHours(3);
-        int updated = gameService.endMatchingGames(deadLine);
-        log.info("[GameScheduler] endMatchingGamesJob finished - updated rows: {}", updated);
+        List<Game> updated = gameService.endMatchingGames(deadLine);
+
+        // TODO - call alarm method, check game is full(if game is not full -> delete game)
+        /*
+        updated.stream()
+               .forEach(this::sendAlarm);
+        */
+
+        log.info("[GameScheduler] endMatchingGamesJob finished - updated rows: {}", updated.size());
     }
 }

--- a/src/main/java/com/b4f2/pting/service/GameService.java
+++ b/src/main/java/com/b4f2/pting/service/GameService.java
@@ -72,7 +72,7 @@ public class GameService {
     }
 
     @Transactional
-    public int endMatchingGames(LocalDateTime deadLine) {
+    public List<Game> endMatchingGames(LocalDateTime deadLine) {
         return gameRepository.endMatchingGames(deadLine);
     }
 
@@ -124,5 +124,9 @@ public class GameService {
         }
 
         gameParticipantRepository.save(new GameParticipant(member, game));
+
+        if (gameParticipants.size() + 1 == game.getPlayerCount()) {
+            // TODO - call alarm method
+        }
     }
 }


### PR DESCRIPTION
푸시 알람을 발송할 조건 트리거들을 구현했습니다.
- 퀵매칭 인원 모집이 완료됐을 때
- 락 걸릴 때(모집 데드라인)

기존 요구사항에서 게임 평가를 위해 게임이 끝나고도 한번 알람을 발송하자했는데 이를 구현하기 위해서는 현재 `Game` Entity의 `gameStatus`에 `ON_MATHCING`, `END` 이외의 새로운 state를 도입해야 할 것 같습니다.
- 게임 모집 중(`ON_MATCHING`) - 현재 `ON_MATCHING`
- 게임 모집 락(`LOCKED`) - 현재 `END`의 상태
- 게임이 끝남(`END`)
