### PR TITLE
Feature/push notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ bin/
 
 ### Environment Variables ###
 .env
+
+### Firebase SDK Configuration ###
+src/main/resources/firebase/*.json

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    implementation 'com.google.firebase:firebase-admin:9.6.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/b4f2/pting/controller/FcmController.java
+++ b/src/main/java/com/b4f2/pting/controller/FcmController.java
@@ -1,0 +1,40 @@
+package com.b4f2.pting.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+
+import lombok.RequiredArgsConstructor;
+
+import com.b4f2.pting.service.FcmService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/push")
+public class FcmController {
+
+    private final FcmService fcmService;
+
+    @PostMapping("/single")
+    public void testSingleNotification() throws FirebaseMessagingException {
+        String title = "FCM 알람 테스트!";
+        String body = "테스트입니다~~";
+        fcmService.sendSinglePush(
+            "fq1nTSy52EwGQnwbpvg-16:APA91bE46Re_2IykaakbJ6fFaCaXcYbG14R8tt15vh-zuqoS3nEdqBSa9o6M9yQ3fPXm7dmCX9p9lSu94lrhIz2Z3CZqSfyZUdG-dxHu9MWaufDnQcQbSak",
+            title, body);
+    }
+
+    @PostMapping("/multicast")
+    public void testMulticastNotification() throws FirebaseMessagingException {
+        String title = "FCM 알람 테스트!";
+        String body = "테스트입니다~~~";
+        fcmService.sendMulticastPush(
+            List.of(
+                "fq1nTSy52EwGQnwbpvg-16:APA91bE46Re_2IykaakbJ6fFaCaXcYbG14R8tt15vh-zuqoS3nEdqBSa9o6M9yQ3fPXm7dmCX9p9lSu94lrhIz2Z3CZqSfyZUdG-dxHu9MWaufDnQcQbSak"
+            ), title, body);
+    }
+}

--- a/src/main/java/com/b4f2/pting/controller/FcmController.java
+++ b/src/main/java/com/b4f2/pting/controller/FcmController.java
@@ -2,7 +2,9 @@ package com.b4f2.pting.controller;
 
 import java.util.List;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,21 +12,30 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 
 import lombok.RequiredArgsConstructor;
 
+import com.b4f2.pting.config.Login;
+import com.b4f2.pting.domain.Member;
+import com.b4f2.pting.dto.FcmTokenRequest;
 import com.b4f2.pting.service.FcmService;
 
 @RestController
+@RequestMapping("/api/v1/fcm")
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/push")
 public class FcmController {
 
     private final FcmService fcmService;
+
+    @PostMapping("/token")
+    public ResponseEntity<String> saveToken(@Login Member member, @RequestBody FcmTokenRequest request) {
+        fcmService.saveToken(member, request.token());
+        return ResponseEntity.ok("FCM 토큰이 저장되었습니다.");
+    }
 
     @PostMapping("/single")
     public void testSingleNotification() throws FirebaseMessagingException {
         String title = "FCM 알람 테스트!";
         String body = "테스트입니다~~";
         fcmService.sendSinglePush(
-            "fq1nTSy52EwGQnwbpvg-16:APA91bE46Re_2IykaakbJ6fFaCaXcYbG14R8tt15vh-zuqoS3nEdqBSa9o6M9yQ3fPXm7dmCX9p9lSu94lrhIz2Z3CZqSfyZUdG-dxHu9MWaufDnQcQbSak",
+            "token",
             title, body);
     }
 
@@ -34,7 +45,8 @@ public class FcmController {
         String body = "테스트입니다~~~";
         fcmService.sendMulticastPush(
             List.of(
-                "fq1nTSy52EwGQnwbpvg-16:APA91bE46Re_2IykaakbJ6fFaCaXcYbG14R8tt15vh-zuqoS3nEdqBSa9o6M9yQ3fPXm7dmCX9p9lSu94lrhIz2Z3CZqSfyZUdG-dxHu9MWaufDnQcQbSak"
+                "token1",
+                "token2"
             ), title, body);
     }
 }

--- a/src/main/java/com/b4f2/pting/controller/GameController.java
+++ b/src/main/java/com/b4f2/pting/controller/GameController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.google.firebase.messaging.FirebaseMessagingException;
+
 import lombok.RequiredArgsConstructor;
 
 import com.b4f2.pting.config.Login;
@@ -32,7 +34,10 @@ public class GameController {
     }
 
     @PostMapping("/{gameId}")
-    public ResponseEntity<Void> joinGame(@Login Member member, @PathVariable Long gameId) {
+    public ResponseEntity<Void> joinGame(
+        @Login Member member,
+        @PathVariable Long gameId
+    ) throws FirebaseMessagingException {
         gameService.joinGame(member, gameId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/b4f2/pting/domain/FcmToken.java
+++ b/src/main/java/com/b4f2/pting/domain/FcmToken.java
@@ -1,0 +1,41 @@
+package com.b4f2.pting.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "fcm_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class FcmToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(name = "token")
+    private String token;
+
+    public FcmToken(Member member, String token) {
+        this.member = member;
+        this.token = token;
+    }
+
+    public void updateToken(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/com/b4f2/pting/domain/Game.java
+++ b/src/main/java/com/b4f2/pting/domain/Game.java
@@ -53,8 +53,9 @@ public class Game {
     private String description;
 
     public enum GameStatus {
-        ON_MATCHING,
-        END
+        ON_RECRUITING, // 모집 중
+        FULL, // 모집 완료
+        END // 게임 종료
     }
 
     public static Game create(
@@ -77,5 +78,9 @@ public class Game {
 
     public boolean isEnded() {
         return this.gameStatus == GameStatus.END;
+    }
+
+    public void changeStatus(GameStatus status) {
+        this.gameStatus = status;
     }
 }

--- a/src/main/java/com/b4f2/pting/dto/FcmTokenRequest.java
+++ b/src/main/java/com/b4f2/pting/dto/FcmTokenRequest.java
@@ -1,0 +1,5 @@
+package com.b4f2.pting.dto;
+
+public record FcmTokenRequest(String token) {
+
+}

--- a/src/main/java/com/b4f2/pting/repository/FcmTokenRepository.java
+++ b/src/main/java/com/b4f2/pting/repository/FcmTokenRepository.java
@@ -1,0 +1,16 @@
+package com.b4f2.pting.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.b4f2.pting.domain.FcmToken;
+import com.b4f2.pting.domain.Member;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+    Optional<FcmToken> findByMember(Member member);
+
+    List<FcmToken> findAllByMemberIn(List<Member> members);
+}

--- a/src/main/java/com/b4f2/pting/service/FcmService.java
+++ b/src/main/java/com/b4f2/pting/service/FcmService.java
@@ -1,0 +1,44 @@
+package com.b4f2.pting.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FcmService {
+
+    public void sendSinglePush(String token, String title, String body) throws FirebaseMessagingException {
+        Message message = Message.builder()
+            .setNotification(Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build())
+            .setToken(token) // 메시지를 받을 유저 브라우저의 FCM 토큰
+            .build();
+
+        FirebaseMessaging.getInstance().send(message);
+    }
+
+    public void sendMulticastPush(List<String> tokens, String title, String body) throws FirebaseMessagingException {
+        MulticastMessage message = MulticastMessage.builder()
+            .setNotification(Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build())
+            .addAllTokens(tokens) // 메시지를 받을 유저 브라우저의 FCM 토큰 리스트
+            .build();
+
+        FirebaseMessaging.getInstance().sendEachForMulticast(message);
+    }
+}

--- a/src/main/java/com/b4f2/pting/service/FcmService.java
+++ b/src/main/java/com/b4f2/pting/service/FcmService.java
@@ -1,6 +1,7 @@
 package com.b4f2.pting.service;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,10 +14,28 @@ import com.google.firebase.messaging.Notification;
 
 import lombok.RequiredArgsConstructor;
 
+import com.b4f2.pting.domain.FcmToken;
+import com.b4f2.pting.domain.Member;
+import com.b4f2.pting.repository.FcmTokenRepository;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class FcmService {
+
+    private final FcmTokenRepository fcmTokenRepository;
+
+    @Transactional
+    public void saveToken(Member member, String token) {
+        Optional<FcmToken> fcmTokenOptional = fcmTokenRepository.findByMember(member);
+
+        if (fcmTokenOptional.isPresent()) {
+            FcmToken fcmToken = fcmTokenOptional.get();
+            fcmToken.updateToken(token);
+        } else {
+            fcmTokenRepository.save(new FcmToken(member, token));
+        }
+    }
 
     public void sendSinglePush(String token, String title, String body) throws FirebaseMessagingException {
         Message message = Message.builder()

--- a/src/main/java/com/b4f2/pting/service/GameService.java
+++ b/src/main/java/com/b4f2/pting/service/GameService.java
@@ -7,8 +7,11 @@ import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.google.firebase.messaging.FirebaseMessagingException;
+
 import lombok.RequiredArgsConstructor;
 
+import com.b4f2.pting.domain.FcmToken;
 import com.b4f2.pting.domain.Game;
 import com.b4f2.pting.domain.GameParticipant;
 import com.b4f2.pting.domain.GameParticipants;
@@ -19,6 +22,7 @@ import com.b4f2.pting.dto.CreateGameRequest;
 import com.b4f2.pting.dto.GameDetailResponse;
 import com.b4f2.pting.dto.GameResponse;
 import com.b4f2.pting.dto.GamesResponse;
+import com.b4f2.pting.repository.FcmTokenRepository;
 import com.b4f2.pting.repository.GameParticipantRepository;
 import com.b4f2.pting.repository.GameRepository;
 import com.b4f2.pting.repository.SportRepository;
@@ -31,6 +35,8 @@ public class GameService {
     private final GameRepository gameRepository;
     private final GameParticipantRepository gameParticipantRepository;
     private final SportRepository sportRepository;
+    private final FcmService fcmService;
+    private final FcmTokenRepository fcmTokenRepository;
 
     @Transactional
     public GameDetailResponse createGame(Member member, CreateGameRequest request) {
@@ -43,7 +49,7 @@ public class GameService {
             sport,
             request.name(),
             request.playerCount(),
-            Game.GameStatus.ON_MATCHING,
+            Game.GameStatus.ON_RECRUITING,
             request.startTime(),
             request.duration(),
             request.description()
@@ -57,23 +63,29 @@ public class GameService {
     }
 
     @Transactional
-    public void joinGame(Member member, Long gameId) {
+    public void joinGame(Member member, Long gameId) throws FirebaseMessagingException {
         validateMemberIsVerified(member);
 
         Game game = gameRepository.findById(gameId)
             .orElseThrow(() -> new EntityNotFoundException("해당 게임이 없습니다."));
 
-        if (game.getGameStatus() != Game.GameStatus.ON_MATCHING) {
+        if (game.getGameStatus() != Game.GameStatus.ON_RECRUITING) {
             throw new IllegalStateException("게임이 모집 중이 아닙니다.");
         }
 
         addParticipant(game, member);
+
+        List<GameParticipant> participants = gameParticipantRepository.findByGame(game);
+        if (participants.size() == game.getPlayerCount()) {
+            game.changeStatus(Game.GameStatus.FULL);
+            notifyMatchingCompleted(participants);
+        }
     }
 
     public GamesResponse findGamesBySportIdAndTimePeriod(Long sportId, TimePeriod timePeriod) {
         if (timePeriod == null) {
             List<GameResponse> gameResponseList = gameRepository
-                .findAllByGameStatusAndSportId(Game.GameStatus.ON_MATCHING, sportId)
+                .findAllByGameStatusAndSportId(Game.GameStatus.ON_RECRUITING, sportId)
                 .stream()
                 .map(GameResponse::new)
                 .toList();
@@ -83,7 +95,7 @@ public class GameService {
 
         List<GameResponse> gameResponseList = gameRepository
             .findAllByGameStatusAndSportIdAndTimePeriod(
-                Game.GameStatus.ON_MATCHING,
+                Game.GameStatus.ON_RECRUITING,
                 sportId,
                 timePeriod.getStartTime(),
                 timePeriod.getEndTime()
@@ -121,4 +133,18 @@ public class GameService {
 
         gameParticipantRepository.save(new GameParticipant(member, game));
     }
+
+    private void notifyMatchingCompleted(List<GameParticipant> participants) throws FirebaseMessagingException {
+        List<Member> members = participants.stream()
+            .map(GameParticipant::getMember)
+            .toList();
+
+        List<String> tokens = fcmTokenRepository.findAllByMemberIn(members).stream()
+            .map(FcmToken::getToken)
+            .toList();
+
+        fcmService.sendMulticastPush(tokens, "매칭 완료", "매칭이 완료되었습니다.");
+    }
+
+    // TODO: 인원 모집이 완료됐던 매칭이 취소될 경우 알림 기능 구현 (참가자가 나갈 경우)
 }

--- a/src/main/java/com/b4f2/pting/util/FcmInitializer.java
+++ b/src/main/java/com/b4f2/pting/util/FcmInitializer.java
@@ -1,0 +1,31 @@
+package com.b4f2.pting.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import jakarta.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+
+@Component
+public class FcmInitializer {
+
+    @Value("${firebase.credentials}")
+    private Resource firebaseCredentials;
+
+    @PostConstruct
+    public void initialize() throws IOException {
+        InputStream serviceAccount = firebaseCredentials.getInputStream();
+        FirebaseOptions options = FirebaseOptions.builder()
+            .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+            .build();
+
+        FirebaseApp.initializeApp(options);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,5 +43,8 @@ spring:
           starttls:
             enable: true
 
+firebase:
+  credentials: classpath:firebase/pting-sdk-credentials.json
+
 app:
   domain: ${SERVER_ADDRESS}

--- a/src/test/java/com/b4f2/pting/service/GameServiceTest.java
+++ b/src/test/java/com/b4f2/pting/service/GameServiceTest.java
@@ -21,6 +21,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.google.firebase.messaging.FirebaseMessagingException;
+
 import com.b4f2.pting.domain.Game;
 import com.b4f2.pting.domain.Member;
 import com.b4f2.pting.domain.Sport;
@@ -65,7 +67,7 @@ class GameServiceTest {
             sport,
             "재미있는 방",
             10,
-            Game.GameStatus.ON_MATCHING,
+            Game.GameStatus.ON_RECRUITING,
             LocalDateTime.now(ZoneId.of("Asia/Seoul")).plusHours(1),
             2,
             "재미있는 방 설명입니다."
@@ -102,7 +104,7 @@ class GameServiceTest {
     }
 
     @Test
-    void joinGame_게임참가_성공() {
+    void joinGame_게임참가_성공() throws FirebaseMessagingException {
         // given
         when(gameRepository.findById(game.getId())).thenReturn(Optional.of(game));
         when(gameParticipantRepository.findByGame(game)).thenReturn(List.of());


### PR DESCRIPTION
Firebase Cloud Messaging을 활용한 푸쉬 알림 기능을 구현했습니다.

- Firebase Credential을 `.gitignore`에 추가했습니다
- FCM 알림 기능 테스트를 위한 컨트롤러 메서드를 구현했습니다
- 멤버별 FCM 토큰 저장을 위한 `FcmToken` 엔티티를 정의했습니다
- 로그인 상태의 멤버가 FCM 토큰을 등록할 수 있도록 하는 기능을 구현했습니다
- `인원 모집 완료 시 알림 발송` 기능 구현을 위해 `GameStatus` enum에 `FULL`을 추가하고, 기존 `ON_MATCHING`을 `ON_RECRUITING`으로 변경했습니다
- `GameService` 클래스의 `joinGame` 메서드에 인원 모집이 완료됐을 경우 알림을 발송하는 기능을 추가했습니다
- 테스트코드에 코드 변경사항을 반영했습니다

- - -

- 현재는 사용자가 한번 참여한 게임에서 나갈 수 없는데, 해당 기능 구현이 필요할 것 같습니다
- 모집 완료 상태의 게임에서 사용자가 나갈 경우, 게임 상태를 다시 `ON_RECRUITING`으로 변경하고 알림을 발송하는 기능을 추가해야 할 것 같습니다